### PR TITLE
Replace bs58 dependency with crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ num-traits = "0.2"
 num-derive = "0.2"
 
 [dev-dependencies]
+bs58 = {version = "0.2.2", features = ["check"]}
 rand = "0.5.5"
 serde_json = "1.0.22"
 serde_derive = "1.0.76"
@@ -35,10 +36,3 @@ byteorder = "1.0.0"
 [build-dependencies]
 pkg-config = "0.3.9"
 regex = "1.0.0"
-
-# This will be replace with the bs58 crate when the checksum changes are
-# merged into it.
-[dev-dependencies.bs58]
-name = "bs58"
-git = "https://github.com/evernym/bs58-rs.git"
-features = ["check"]

--- a/tests/pool.rs
+++ b/tests/pool.rs
@@ -641,7 +641,7 @@ mod close_pool {
 
         let pool_handle = indy::pool::Pool::open_ledger(&setup.pool_name, None).unwrap();
 
-        let get_nym_req = indy::ledger::Ledger::build_get_nym_request(DID_1, DID_1).unwrap();
+        let get_nym_req = indy::ledger::Ledger::build_get_nym_request(Some(DID_1), DID_1).unwrap();
 
         let (sender, receiver) = channel();
 
@@ -670,7 +670,7 @@ mod close_pool {
 
         let pool_handle = indy::pool::Pool::open_ledger(&setup.pool_name, None).unwrap();
 
-        let get_nym_req = indy::ledger::Ledger::build_get_nym_request(DID_1, DID_1).unwrap();
+        let get_nym_req = indy::ledger::Ledger::build_get_nym_request(Some(DID_1), DID_1).unwrap();
 
         let (sender, receiver) = channel();
 
@@ -705,7 +705,7 @@ mod close_pool {
 
         let pool_handle = indy::pool::Pool::open_ledger(&setup.pool_name, None).unwrap();
 
-        let get_nym_req = indy::ledger::Ledger::build_get_nym_request(DID_1, DID_1).unwrap();
+        let get_nym_req = indy::ledger::Ledger::build_get_nym_request(Some(DID_1), DID_1).unwrap();
 
         let (sender, receiver) = channel();
 
@@ -1083,7 +1083,7 @@ mod test_set_protocol_version {
 
     fn assert_protocol_version_set(version: usize) {
         let did = "5UBVMdSADMjGzuJMQwJ6yyzYV1krTcKRp6EqRAz8tiDP";
-        let request = Ledger::build_get_nym_request(did, did).unwrap();
+        let request = Ledger::build_get_nym_request(Some(did), did).unwrap();
         let request: serde_json::Value = serde_json::from_str(&request).unwrap();
         assert_eq!(json!(version), *request.get("protocolVersion").unwrap());
     }


### PR DESCRIPTION
The checksum changes have been merged into the bs58 crate.
This changes the Cargo.toml bs58 dependency from GitHub to crates.io.

The pool tests were broken from the api changes with optional did.
This implements the changes in the pool tests.

Signed-off-by: dastardlychimp <darien.hess@evernym.com>